### PR TITLE
feat: support multiple patterns

### DIFF
--- a/lib/postgrator-cli.js
+++ b/lib/postgrator-cli.js
@@ -1,10 +1,10 @@
+import getUsage from 'command-line-usage';
+import { lilconfig } from 'lilconfig';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import getUsage from 'command-line-usage';
-import Postgrator from 'postgrator';
-import { lilconfig } from 'lilconfig';
-import yaml from 'yaml';
 import tap from 'p-tap';
+import Postgrator from 'postgrator';
+import yaml from 'yaml';
 import getClient from './clients/index.js'; // eslint-disable-line import/extensions
 import parse, { sections } from './command-line-options.js'; // eslint-disable-line import/extensions
 
@@ -23,16 +23,20 @@ function getMigrateToNumber(toArgument) {
 }
 
 function getAbsolutePath(fileOrDirectory) {
-    const absPath = (path.isAbsolute(fileOrDirectory))
-        ? fileOrDirectory
-        : path.join(process.cwd(), fileOrDirectory);
+    if (!Array.isArray(fileOrDirectory)) fileOrDirectory = [fileOrDirectory];
 
-    // Paths must use posix forward slashes to work properly ever since
-    // postgrator updated to the newer version of glob
-    //
-    // https://github.com/rickbergfalk/postgrator/blob/master/CHANGELOG.md#800
-    // https://github.com/isaacs/node-glob/blob/main/changelog.md#81
-    return absPath.replaceAll(path.sep, path.posix.sep);
+    return fileOrDirectory.map((targetPath) => {
+        const absPath = (path.isAbsolute(targetPath))
+            ? targetPath
+            : path.join(process.cwd(), targetPath);
+
+        // Paths must use posix forward slashes to work properly ever since
+        // postgrator updated to the newer version of glob
+        //
+        // https://github.com/rickbergfalk/postgrator/blob/master/CHANGELOG.md#800
+        // https://github.com/isaacs/node-glob/blob/main/changelog.md#81
+        return absPath.replaceAll(path.sep, path.posix.sep);
+    });
 }
 
 const loadYaml = (_, content) => yaml.parse(content);

--- a/test/multi-patterns-config/.postgratorrc.json
+++ b/test/multi-patterns-config/.postgratorrc.json
@@ -1,0 +1,9 @@
+{
+    "migrationPattern": ["../migrations/*", "../seeds/*"],
+    "driver": "pg",
+    "host": "127.0.0.1",
+    "port": 5432,
+    "database": "postgrator",
+    "username": "postgrator",
+    "password": "postgrator"
+}

--- a/test/seeds/006.do.some-description.sql
+++ b/test/seeds/006.do.some-description.sql
@@ -1,0 +1,5 @@
+-- Test 1 insert
+INSERT INTO
+    person (name, age)
+VALUES
+    ('jhon', 30);

--- a/test/seeds/006.undo.some-description.sql
+++ b/test/seeds/006.undo.some-description.sql
@@ -1,0 +1,6 @@
+-- remove the record
+DELETE FROM
+    person
+WHERE
+    name = 'jhon'
+    AND age = 30;


### PR DESCRIPTION
Postgrator uses glob. Glob supports multiple patterns.
Now you can specify the migration pattern as 
```json
{
  "migrationPattern": ["migrations/*", "seeds/*"],
  "driver": "pg",
  "host": "127.0.0.1",
  "port": 5432,
  "database": "your_finance_db",
  "username": "your_user",
  "password": "your_password"
}
```