### PR TITLE
feat(sqlite3)!: use built-in node:sqlite instead of the sqlite3 package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 20.x
-                    - 22.x
+                    - 22.13.0
                     - 24.x
                     - 26.x
                 mssql-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 22.13.0
+                    - 22.16.0
                     - 24.x
                     - 26.x
                 mssql-version:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Uses [Postgrator](https://github.com/rickbergfalk/postgrator) node.js library de
 
 ## Installation
 
-*As of postgrator-cli 6 Node.js version 14 or greater is required*
+*As of postgrator-cli 10 Node.js version 22.13 or greater is required (sqlite3 support is provided by the built-in `node:sqlite` module)*
 
 ```
 npm install -g postgrator-cli
@@ -32,7 +32,6 @@ And install the appropriate DB engine(s) if not installed yet:
 npm install pg@8
 npm install mysql@2
 npm install mssql@6
-npm install sqlite3@5
 ```
 
 See the [Postgrator](https://github.com/rickbergfalk/postgrator) documentation for more information about the supported engines.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Uses [Postgrator](https://github.com/rickbergfalk/postgrator) node.js library de
 
 ## Installation
 
-*As of postgrator-cli 10 Node.js version 22.13 or greater is required (sqlite3 support is provided by the built-in `node:sqlite` module)*
+*As of postgrator-cli 10 Node.js version 22.16, or 24.0 or greater is required (sqlite3 support is provided by the built-in `node:sqlite` module)*
 
 ```
 npm install -g postgrator-cli

--- a/lib/clients/sqlite3.js
+++ b/lib/clients/sqlite3.js
@@ -6,8 +6,8 @@ export default ({ database }) => {
 
     return {
         connect: () => {},
-        query: async (query) => ({ rows: db.prepare(query).all() }),
-        execSqlScript: async (query) => db.exec(query),
-        end: async () => db.close(),
+        query: (query) => ({ rows: db.prepare(query).all() }),
+        execSqlScript: (query) => db.exec(query),
+        end: () => db.close(),
     };
 };

--- a/lib/clients/sqlite3.js
+++ b/lib/clients/sqlite3.js
@@ -1,29 +1,13 @@
-import { promisify } from "node:util";
-import sqlite3 from "sqlite3";
+// eslint-disable-next-line n/no-unsupported-features/node-builtins -- node:sqlite is a release candidate, not yet marked stable
+import { DatabaseSync } from "node:sqlite";
 
 export default ({ database }) => {
-    const db = new sqlite3.Database(database || ":memory:");
+    const db = new DatabaseSync(database || ":memory:");
 
     return {
         connect: () => {},
-        query: (query) =>
-            new Promise((resolve, reject) => {
-                db.all(query, (err, rows) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    return resolve({ rows });
-                });
-            }),
-        execSqlScript: (query) =>
-            new Promise((resolve, reject) => {
-                db.exec(query, (err) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    return resolve();
-                });
-            }),
-        end: promisify(db.close.bind(db)),
+        query: async (query) => ({ rows: db.prepare(query).all() }),
+        execSqlScript: async (query) => db.exec(query),
+        end: async () => db.close(),
     };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,17 +40,15 @@
                 "p-each-series": "^3.0.0",
                 "p-event": "^7.1.0",
                 "pg": "^8.22.0",
-                "prettier": "3.9.5",
-                "sqlite3": "^6.0.1"
+                "prettier": "3.9.5"
             },
             "engines": {
-                "node": "^20.11.0 || >=22.0.0"
+                "node": "^22.13.0 || >=23.4.0"
             },
             "peerDependencies": {
                 "mssql": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
                 "mysql": "^2.0.0",
-                "pg": "^8.0.0",
-                "sqlite3": "^5.0.0"
+                "pg": "^8.0.0"
             },
             "peerDependenciesMeta": {
                 "mssql": {
@@ -60,9 +58,6 @@
                     "optional": true
                 },
                 "pg": {
-                    "optional": true
-                },
-                "sqlite3": {
                     "optional": true
                 }
             }
@@ -508,16 +503,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@gar/promise-retry": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
-            "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -672,18 +657,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/@isaacs/fs-minipass": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-            "dev": true,
-            "dependencies": {
-                "minipass": "^7.0.4"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -723,69 +696,6 @@
             "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-6.0.1.tgz",
             "integrity": "sha512-Iev3Cfa3MC+06JXXeFzSLew/7yeCXLMhjesyH/BD4EQYlUUDV49Ln3s8hd7p5XK5UesO/dO3K1LFJ7RT7v0Ddg==",
             "dev": true
-        },
-        "node_modules/@npmcli/agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^11.2.1",
-                "socks-proxy-agent": "^8.0.3"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@npmcli/agent/node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@npmcli/fs/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "optional": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@npmcli/redact": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
         },
         "node_modules/@ota-meshi/ast-token-store": {
             "version": "0.3.0",
@@ -887,16 +797,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/abbrev": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/abort-controller": {
@@ -1180,15 +1080,6 @@
                 "node": "*"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "node_modules/bl": {
             "version": "6.1.6",
             "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
@@ -1422,95 +1313,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cacache": {
-            "version": "20.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "@npmcli/fs": "^5.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^13.0.0",
-                "lru-cache": "^11.1.0",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/cacache/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/cacache/node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -1703,15 +1505,6 @@
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/ci-info": {
             "version": "4.4.0",
@@ -1923,30 +1716,6 @@
                 }
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2040,15 +1809,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2108,15 +1868,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "dev": true,
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
         "node_modules/enhanced-resolve": {
             "version": "5.17.1",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
@@ -2128,16 +1879,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/es-abstract": {
@@ -3017,22 +2758,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/exponential-backoff": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-            "dev": true,
-            "optional": true
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3060,24 +2785,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
-        "node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3090,12 +2797,6 @@
             "engines": {
                 "node": ">=16.0.0"
             }
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true
         },
         "node_modules/find-replace": {
             "version": "5.0.2",
@@ -3186,25 +2887,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
-        },
-        "node_modules/fs-minipass": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-            "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^7.0.3"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/function-bind": {
@@ -3319,12 +3001,6 @@
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
-        },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "dev": true
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
@@ -3504,13 +3180,6 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
-        "node_modules/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "dev": true,
-            "optional": true
-        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3637,12 +3306,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true
-        },
         "node_modules/internal-slot": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -3655,16 +3318,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -4422,30 +4075,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/make-fetch-happen": {
-            "version": "15.0.5",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "@gar/promise-retry": "^1.0.0",
-                "@npmcli/agent": "^4.0.0",
-                "@npmcli/redact": "^4.0.0",
-                "cacache": "^20.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^6.0.0",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4453,18 +4082,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimatch": {
@@ -4492,120 +4109,6 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/minipass-collect": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-            "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^7.0.3"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/minipass-fetch": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^7.0.3",
-                "minipass-sized": "^2.0.0",
-                "minizlib": "^3.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            },
-            "optionalDependencies": {
-                "iconv-lite": "^0.7.2"
-            }
-        },
-        "node_modules/minipass-flush": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minipass-pipeline": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minipass-pipeline/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minipass-sized": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
-            "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "node_modules/mock-cwd": {
             "version": "1.0.0",
@@ -4687,12 +4190,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/napi-build-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "dev": true
-        },
         "node_modules/native-duplexpair": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
@@ -4705,113 +4202,6 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
-        "node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/node-abi": {
-            "version": "3.89.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-            "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-            "dev": true,
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-abi/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-addon-api": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-            "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
-            "dev": true,
-            "engines": {
-                "node": "^18 || ^20 || >= 21"
-            }
-        },
-        "node_modules/node-gyp": {
-            "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
-            "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "env-paths": "^2.2.0",
-                "exponential-backoff": "^3.1.1",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^15.0.0",
-                "nopt": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "tar": "^7.5.4",
-                "tinyglobby": "^0.2.12",
-                "which": "^6.0.0"
-            },
-            "bin": {
-                "node-gyp": "bin/node-gyp.js"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/isexe": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/node-gyp/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "optional": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-gyp/node_modules/which": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "isexe": "^4.0.0"
-            },
-            "bin": {
-                "node-which": "bin/which.js"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.51",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -4820,22 +4210,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/nopt": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "abbrev": "^4.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/object-inspect": {
@@ -5026,19 +4400,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/p-tap": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-tap/-/p-tap-4.0.0.tgz",
@@ -5223,19 +4584,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/pluralize": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -5373,33 +4721,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/prebuild-install": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-            "dev": true,
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^2.0.0",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5438,16 +4759,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/proc-log": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5462,16 +4773,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
-        },
-        "node_modules/pump": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-            "dev": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -5503,44 +4804,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "node_modules/rc/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -5891,92 +5154,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "ip-address": "^10.0.1",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/split2": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -5993,33 +5170,6 @@
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true
         },
-        "node_modules/sqlite3": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
-            "integrity": "sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "node-addon-api": "^8.0.0",
-                "prebuild-install": "^7.1.3",
-                "tar": "^7.5.10"
-            },
-            "engines": {
-                "node": ">=20.17.0"
-            },
-            "optionalDependencies": {
-                "node-gyp": "12.x"
-            },
-            "peerDependencies": {
-                "node-gyp": "12.x"
-            },
-            "peerDependenciesMeta": {
-                "node-gyp": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/sqlstring": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
@@ -6027,19 +5177,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/ssri": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-            "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "minipass": "^7.0.3"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/stop-iteration-iterator": {
@@ -6254,100 +5391,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "dev": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-fs/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tar-stream/node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/tar-stream/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/tar/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/tarn": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
@@ -6454,23 +5497,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "node_modules/transform-file": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/transform-file/-/transform-file-1.0.1.tgz",
@@ -6497,18 +5523,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true
-        },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -7349,13 +6363,6 @@
                 "levn": "^0.4.1"
             }
         },
-        "@gar/promise-retry": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
-            "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
-            "dev": true,
-            "optional": true
-        },
         "@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -7452,15 +6459,6 @@
                 }
             }
         },
-        "@isaacs/fs-minipass": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-            "dev": true,
-            "requires": {
-                "minipass": "^7.0.4"
-            }
-        },
         "@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -7494,55 +6492,6 @@
             "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-6.0.1.tgz",
             "integrity": "sha512-Iev3Cfa3MC+06JXXeFzSLew/7yeCXLMhjesyH/BD4EQYlUUDV49Ln3s8hd7p5XK5UesO/dO3K1LFJ7RT7v0Ddg==",
             "dev": true
-        },
-        "@npmcli/agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^11.2.1",
-                "socks-proxy-agent": "^8.0.3"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "11.2.7",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-                    "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-                    "dev": true,
-                    "optional": true
-                }
-            }
-        },
-        "@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "semver": "^7.3.5"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.7.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-                    "dev": true,
-                    "optional": true
-                }
-            }
-        },
-        "@npmcli/redact": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
-            "dev": true,
-            "optional": true
         },
         "@ota-meshi/ast-token-store": {
             "version": "0.3.0",
@@ -7626,13 +6575,6 @@
                 "https-proxy-agent": "^7.0.0",
                 "tslib": "^2.6.2"
             }
-        },
-        "abbrev": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
-            "dev": true,
-            "optional": true
         },
         "abort-controller": {
             "version": "3.0.0",
@@ -7815,15 +6757,6 @@
             "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
             "dev": true
         },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "bl": {
             "version": "6.1.6",
             "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
@@ -7969,73 +6902,6 @@
                 }
             }
         },
-        "cacache": {
-            "version": "20.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "@npmcli/fs": "^5.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^13.0.0",
-                "lru-cache": "^11.1.0",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^13.0.0"
-            },
-            "dependencies": {
-                "balanced-match": {
-                    "version": "4.0.4",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-                    "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "brace-expansion": {
-                    "version": "5.0.5",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-                    "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "balanced-match": "^4.0.2"
-                    }
-                },
-                "glob": {
-                    "version": "13.0.6",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-                    "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^10.2.2",
-                        "minipass": "^7.1.3",
-                        "path-scurry": "^2.0.2"
-                    }
-                },
-                "lru-cache": {
-                    "version": "11.2.7",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-                    "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "10.2.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-                    "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "brace-expansion": "^5.0.2"
-                    }
-                }
-            }
-        },
         "call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -8160,12 +7026,6 @@
             "version": "5.4.4",
             "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-            "dev": true
-        },
-        "chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
             "dev": true
         },
         "ci-info": {
@@ -8313,21 +7173,6 @@
                 "ms": "2.1.2"
             }
         },
-        "decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
-            "requires": {
-                "mimic-response": "^3.1.0"
-            }
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true
-        },
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -8384,12 +7229,6 @@
             "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
             "dev": true
         },
-        "detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true
-        },
         "diff-sequences": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -8439,15 +7278,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
-        "end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "dev": true,
-            "requires": {
-                "once": "^1.4.0"
-            }
-        },
         "enhanced-resolve": {
             "version": "5.17.1",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
@@ -8457,13 +7287,6 @@
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
             }
-        },
-        "env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "dev": true,
-            "optional": true
         },
         "es-abstract": {
             "version": "1.24.0",
@@ -9055,19 +7878,6 @@
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true
         },
-        "expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "dev": true
-        },
-        "exponential-backoff": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-            "dev": true,
-            "optional": true
-        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9092,14 +7902,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
-        "fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "optional": true,
-            "requires": {}
-        },
         "file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -9108,12 +7910,6 @@
             "requires": {
                 "flat-cache": "^4.0.0"
             }
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true
         },
         "find-replace": {
             "version": "5.0.2",
@@ -9166,22 +7962,6 @@
                     "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
                     "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
                 }
-            }
-        },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
-        },
-        "fs-minipass": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-            "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "^7.0.3"
             }
         },
         "function-bind": {
@@ -9263,12 +8043,6 @@
             "requires": {
                 "resolve-pkg-maps": "^1.0.0"
             }
-        },
-        "github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "dev": true
         },
         "glob-parent": {
             "version": "6.0.2",
@@ -9392,13 +8166,6 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
-        "http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "dev": true,
-            "optional": true
-        },
         "http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -9478,12 +8245,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true
-        },
         "internal-slot": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9494,13 +8255,6 @@
                 "hasown": "^2.0.2",
                 "side-channel": "^1.1.0"
             }
-        },
-        "ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-            "dev": true,
-            "optional": true
         },
         "is-array-buffer": {
             "version": "3.0.5",
@@ -10013,37 +8767,10 @@
                 "yallist": "^4.0.0"
             }
         },
-        "make-fetch-happen": {
-            "version": "15.0.5",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "@gar/promise-retry": "^1.0.0",
-                "@npmcli/agent": "^4.0.0",
-                "@npmcli/redact": "^4.0.0",
-                "cacache": "^20.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^6.0.0",
-                "ssri": "^13.0.0"
-            }
-        },
         "math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true
-        },
-        "mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true
         },
         "minimatch": {
@@ -10065,98 +8792,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
-        },
-        "minipass-collect": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-            "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "^7.0.3"
-            }
-        },
-        "minipass-fetch": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "iconv-lite": "^0.7.2",
-                "minipass": "^7.0.3",
-                "minipass-sized": "^2.0.0",
-                "minizlib": "^3.0.1"
-            }
-        },
-        "minipass-flush": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "^3.0.0"
-            },
-            "dependencies": {
-                "minipass": {
-                    "version": "3.3.6",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "minipass-pipeline": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "^3.0.0"
-            },
-            "dependencies": {
-                "minipass": {
-                    "version": "3.3.6",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "minipass-sized": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
-            "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "^7.1.2"
-            }
-        },
-        "minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "requires": {
-                "minipass": "^7.1.2"
-            }
-        },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "mock-cwd": {
             "version": "1.0.0",
@@ -10231,12 +8866,6 @@
                 }
             }
         },
-        "napi-build-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "dev": true
-        },
         "native-duplexpair": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
@@ -10249,96 +8878,11 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
-        "negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-            "dev": true,
-            "optional": true
-        },
-        "node-abi": {
-            "version": "3.89.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-            "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-            "dev": true,
-            "requires": {
-                "semver": "^7.3.5"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.7.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-                    "dev": true
-                }
-            }
-        },
-        "node-addon-api": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-            "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
-            "dev": true
-        },
-        "node-gyp": {
-            "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
-            "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "env-paths": "^2.2.0",
-                "exponential-backoff": "^3.1.1",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^15.0.0",
-                "nopt": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "tar": "^7.5.4",
-                "tinyglobby": "^0.2.12",
-                "which": "^6.0.0"
-            },
-            "dependencies": {
-                "isexe": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-                    "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "7.7.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "which": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-                    "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "isexe": "^4.0.0"
-                    }
-                }
-            }
-        },
         "node-releases": {
             "version": "2.0.51",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
             "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true
-        },
-        "nopt": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "abbrev": "^4.0.0"
-            }
         },
         "object-inspect": {
             "version": "1.13.4",
@@ -10467,13 +9011,6 @@
             "requires": {
                 "p-timeout": "^7.0.1"
             }
-        },
-        "p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-            "dev": true,
-            "optional": true
         },
         "p-tap": {
             "version": "4.0.0",
@@ -10607,13 +9144,6 @@
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true
         },
-        "picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "optional": true
-        },
         "pluralize": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -10705,26 +9235,6 @@
                 "xtend": "^4.0.0"
             }
         },
-        "prebuild-install": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "dev": true,
-            "requires": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^2.0.0",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            }
-        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10746,13 +9256,6 @@
                 "fast-diff": "^1.1.2"
             }
         },
-        "proc-log": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-            "dev": true,
-            "optional": true
-        },
         "process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -10764,16 +9267,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
-        },
-        "pump": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "punycode": {
             "version": "2.3.1",
@@ -10795,37 +9288,6 @@
             "requires": {
                 "array-uniq": "1.0.2",
                 "randombytes": "2.0.3"
-            }
-        },
-        "rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
-            "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "dependencies": {
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-                    "dev": true
-                }
-            }
-        },
-        "readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
             }
         },
         "reflect.getprototypeof": {
@@ -11068,53 +9530,6 @@
                 "side-channel-map": "^1.0.1"
             }
         },
-        "simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true
-        },
-        "simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "dev": true,
-            "requires": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
-        "smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true,
-            "optional": true
-        },
-        "socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "ip-address": "^10.0.1",
-                "smart-buffer": "^4.2.0"
-            }
-        },
-        "socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            }
-        },
         "split2": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -11127,34 +9542,11 @@
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true
         },
-        "sqlite3": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
-            "integrity": "sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==",
-            "dev": true,
-            "requires": {
-                "bindings": "^1.5.0",
-                "node-addon-api": "^8.0.0",
-                "node-gyp": "12.x",
-                "prebuild-install": "^7.1.3",
-                "tar": "^7.5.10"
-            }
-        },
         "sqlstring": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
             "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=",
             "dev": true
-        },
-        "ssri": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-            "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "^7.0.3"
-            }
         },
         "stop-iteration-iterator": {
             "version": "1.1.0",
@@ -11297,83 +9689,6 @@
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true
         },
-        "tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "requires": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "dependencies": {
-                "yallist": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-                    "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-                    "dev": true
-                }
-            }
-        },
-        "tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "dev": true,
-            "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            },
-            "dependencies": {
-                "chownr": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-                    "dev": true
-                }
-            }
-        },
-        "tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
-            "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "dependencies": {
-                "bl": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-                    "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-                    "dev": true,
-                    "requires": {
-                        "buffer": "^5.5.0",
-                        "inherits": "^2.0.4",
-                        "readable-stream": "^3.4.0"
-                    }
-                },
-                "buffer": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-                    "dev": true,
-                    "requires": {
-                        "base64-js": "^1.3.1",
-                        "ieee754": "^1.1.13"
-                    }
-                }
-            }
-        },
         "tarn": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
@@ -11452,17 +9767,6 @@
                 }
             }
         },
-        "tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            }
-        },
         "transform-file": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/transform-file/-/transform-file-1.0.1.tgz",
@@ -11489,15 +9793,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
         },
         "type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "postgrator": "./index.js"
     },
     "engines": {
-        "node": "^20.11.0 || >=22.0.0"
+        "node": "^22.13.0 || >=23.4.0"
     },
     "scripts": {
         "lint": "eslint --cache .",
@@ -75,23 +75,18 @@
         "p-each-series": "^3.0.0",
         "p-event": "^7.1.0",
         "pg": "^8.22.0",
-        "prettier": "3.9.5",
-        "sqlite3": "^6.0.1"
+        "prettier": "3.9.5"
     },
     "peerDependencies": {
         "mssql": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "mysql": "^2.0.0",
-        "pg": "^8.0.0",
-        "sqlite3": "^5.0.0"
+        "pg": "^8.0.0"
     },
     "peerDependenciesMeta": {
         "mssql": {
             "optional": true
         },
         "mysql": {
-            "optional": true
-        },
-        "sqlite3": {
             "optional": true
         },
         "pg": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "postgrator": "./index.js"
     },
     "engines": {
-        "node": "^22.13.0 || >=23.4.0"
+        "node": "^22.16.0 || >=24.0.0"
     },
     "scripts": {
         "lint": "eslint --cache .",

--- a/test/postgrator-cli-tests.js
+++ b/test/postgrator-cli-tests.js
@@ -215,7 +215,6 @@ function buildTestsForOptions(options) {
             });
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "sample-config"),
                 async () => {
                     await expect(run(args)).to.eventually.containSubset({
@@ -236,7 +235,6 @@ function buildTestsForOptions(options) {
             });
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "sample-config-esm"),
                 async () => {
                     await expect(run(args)).to.eventually.containSubset({
@@ -257,7 +255,6 @@ function buildTestsForOptions(options) {
             });
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "sample-config-cjs"),
                 async () => {
                     await expect(run(args)).to.eventually.containSubset({
@@ -278,7 +275,6 @@ function buildTestsForOptions(options) {
             });
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "multi-patterns-config"),
                 async () => {
                     await expect(run(args)).to.eventually.containSubset({
@@ -303,7 +299,6 @@ function buildTestsForOptions(options) {
             });
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "multi-patterns-config"),
                 async () => {
                     await expect(run(args)).to.eventually.containSubset([
@@ -321,9 +316,8 @@ function buildTestsForOptions(options) {
                 to: "06",
 
                 "migration-pattern": [
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
                     path.join(import.meta.dirname, "migrations/*"),
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+
                     path.join(import.meta.dirname, "seeds/*"),
                 ],
             });
@@ -346,9 +340,8 @@ function buildTestsForOptions(options) {
                 to: "02",
 
                 "migration-pattern": [
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
                     path.join(import.meta.dirname, "migrations/*"),
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+
                     path.join(import.meta.dirname, "seeds/*"),
                 ],
             });
@@ -405,7 +398,6 @@ function buildTestsForOptions(options) {
             );
             const args = getArgList({
                 config: path.resolve(
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
                     import.meta.dirname,
                     "./sample-config.json",
                 ),
@@ -419,7 +411,6 @@ function buildTestsForOptions(options) {
             );
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "sample-config"),
                 async () => {
                     await expect(run()).to.eventually.have.lengthOf(0);
@@ -435,7 +426,6 @@ function buildTestsForOptions(options) {
                 username: "invaliduser",
 
                 config: path.resolve(
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
                     import.meta.dirname,
                     "./sample-config.json",
                 ),
@@ -497,7 +487,6 @@ function buildTestsForOptions(options) {
 
             return mockCwd(
                 path.join(
-                    // eslint-disable-next-line n/no-unsupported-features/node-builtins
                     import.meta.dirname,
                     "config-with-non-existing-directory",
                 ),
@@ -522,7 +511,6 @@ function buildTestsForOptions(options) {
             });
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "config-with-other-directory"),
                 async () => {
                     await expect(run(args)).to.eventually.have.lengthOf(2);
@@ -743,7 +731,6 @@ function buildTestsForOptions(options) {
             );
 
             return mockCwd(
-                // eslint-disable-next-line n/no-unsupported-features/node-builtins
                 path.join(import.meta.dirname, "sample-config"),
                 async () => {
                     await expect(run(["0"])).to.eventually.have.lengthOf(0);


### PR DESCRIPTION
## Summary
- `lib/clients/sqlite3.js` now uses Node's built-in `node:sqlite` (`DatabaseSync`) instead of the `sqlite3` npm package (which ships prebuilt native binaries and requires separate installation).
- `node:sqlite`'s `db.exec()` natively runs multi-statement scripts, so the `execSqlScript` fix from #313 continues to work the same way, just without depending on an external package.
- Dropped `sqlite3` from `devDependencies`, `peerDependencies`, and `peerDependenciesMeta` — it's no longer needed at all, in userland or in this repo.
- Bumped `engines.node` to `^22.13.0 || >=23.4.0` (the versions where `node:sqlite` works without the `--experimental-sqlite` flag), dropping Node 20 support.
- Updated `README.md` (dropped `npm install sqlite3@5`, updated the Node version requirement note) and the CI test matrix (dropped `20.x`, pinned `22.13.0` as the floor instead of `22.x`).

## BREAKING CHANGE
Node.js >= 22.13.0 (or >= 23.4.0) is now required. Users on Node 20 will need to stay on postgrator-cli 9.x. Users don't need to `npm install sqlite3` anymore for sqlite3 support — it's built in.

## Test plan
- [x] Verified `query`/`execSqlScript`/`end` against `:memory:` and file-backed databases (including that a file-backed DB persists data across separate client connections).
- [x] Verified the full migration flow (multi-statement `001.do.sql`/`003.do.sql`, migrate up to 3 and back down to 0) via a direct `Postgrator` instance.
- [x] Verified the same flow end-to-end through the CLI's `run()`.
- [x] Verified error propagation for invalid SQL in both `query` and `execSqlScript`.
- [x] `npx eslint .` and `npx prettier --check .` pass (aside from pre-existing markdown formatting warnings unrelated to this change).
- [ ] Could not run the full `npm test` suite locally (pg/mysql/mssql require docker-compose, unavailable in this sandbox) — please confirm CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)